### PR TITLE
修复进度少于 50 时在安卓上显示不正确的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
 # react-native-percentage-circle
+
 [![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)]()
 [![npm](https://img.shields.io/npm/v/react-native-percentage-circle.svg?maxAge=2592000)]()
-
-
 
 <img width="400" src="http://img1.vued.vanthink.cn/vuede4474d80623ab3d17f2ca5aeb1ccd194.png"/>
 
 React Native Version >= 0.25
 
-React-Native-Percentage-Cirlce is a component which supports you define your percent and draw the circle.And also you can use it as a progress bar.And you can show some data in a circle you want.
+React-Native-Percentage-Cirlce is a component which supports you define your
+percent and draw the circle.And also you can use it as a progress bar.And you
+can show some data in a circle you want.
 
 [react.js version](https://github.com/JackPu/reactjs-percentage-circle)
 
 <img width="480" src="http://img1.vued.vanthink.cn/vued9c00a0a75734849d01def751ca10f248.png"/>
 
-*This is a screenshot of the Demo*
+_This is a screenshot of the Demo_
 
-### Start 
+### Start
 
-``` bash
+```bash
 npm i react-native-percentage-circle --save
-
 ```
 
-``` js
-
+```js
 import PercentageCircle from 'react-native-percentage-circle';
 
 //...
@@ -39,27 +38,24 @@ render() {
     </PercentageCircle>  
   </View>
 }
-
 ```
 
 ### Options
 
-| Props        | Type         | Example  | Description  |
-| ------------- |:-------------:| -----:|----------:|
-| color     | string | '#000' | the color of border |
-| bgcolor     | string | '#e3e3e3' | the background color of the circle  |
-| innerColor     | string | '#fff' | the color of the inside of the circle  |
-| percent      | Number      |  30 | the percent you need |
-| radius | Number     |    20 | how large the circle is |
-| borderWidth | Number(default 2)     |    5 | the width of  percentage progress bar |
-| textStyle | Array   | {fontSize: 24, color: 'red'} | define the style of the text which in the circle |
-| children | jsx   | `<Text>123</Text>` | define the children component in the circle |
+| Props       |       Type        |                          Example |                                                            Description |
+| ----------- | :---------------: | -------------------------------: | ---------------------------------------------------------------------: |
+| color       |      string       |                           `#000` |                                                    the color of border |
+| bgcolor     |      string       |                        `#e3e3e3` |                                     the background color of the circle |
+| innerColor  |      string       |                           `#fff` |                                  the color of the inside of the circle |
+| percent     |      Number       |                             `30` |                                                   the percent you need |
+| radius      |      Number       |                             `20` |                                                how large the circle is |
+| borderWidth | Number(default 2) |                              `5` |                                   the width of percentage progress bar |
+| textStyle   |       Array       | `[{fontSize: 24, color: 'red'}]` |                       define the style of the text which in the circle |
+| rotate      |      Number       |                             `40` | if you want progress circle starts at 3 o'clock, set this prop into 90 |
+| children    |        jsx        |               `<Text>123</Text>` |                            define the children component in the circle |
 
 ### Contributions
 
 Your contributions and suggestions are welcome 😄😄😄
 
 ### MIT License
-
-
-

--- a/index.js
+++ b/index.js
@@ -2,164 +2,261 @@
  ** @github  https://github.com/JackPu/react-native-percentage-circle
  ** React Native Version >=0.25
  ** to fixed react native version
+ *
+ * 改模块源自 JackPu 的 react-native-percentage-circle v1.0.7
+ *
+ * 原模块在安卓手机上，当 percent 小于 50 时，进度圆环绘制会出现错误。
+ *
+ * 原因如下：
+ *
+ * 参见 React native 0.51 Known Issues(https://reactnative.cn/docs/0.51/known-issues.html)
+ *
+ * > overflow 样式在 Android 默认为 hidden 而且无法更改，且如果父容器有borderRadius圆角边框样式，
+ * > 那么即便开启了overflow:hidden也仍然无法把子视图超出圆角边框的部分裁切掉。
+ * > 这个问题只存在于Android上，iOS并没有这个问题
+ *
+ * 由于无法裁剪超出圆角边框的部分，所以即便当 percent < 50 时，设置 LeftTransformerDegree 为 0，
+ * View#LeftTransformer 的半圆仍会显示在页面上。
+ *
+ * 因此本模块修改了 LeftTransformer 与 RightTransformer 的视图顺序，
+ * 并且在 percent < 50 时，LeftTransformer 旋转 180 度，同时将其颜色修改为与底色相同。
+ *
+ *
+ * Tested in devices as bellow:
+ * * Android:
+ *   - Device: XiaoMi 5
+ *   - OS: Android 6.0.1 MXB48T
+ *   - react: 15.4.1
+ *   - react-native: 0.39.2
+ *
+ * * iOS:
+ *   - Device: iPhone 6s
+ *   - OS: iOS 11.4
+ *   - react: 15.3.1
+ *   - react-native: 0.33.1
  **/
 
-import React, { Component } from 'react';
-import {
-  StyleSheet,
-  View,
-  Text,
-} from 'react-native';
+import React, { Component } from "react";
+import { StyleSheet, View, Text } from "react-native";
 
 const styles = StyleSheet.create({
   circle: {
-    overflow: 'hidden',
-    position: 'relative',
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#e3e3e3',
+    overflow: "hidden",
+    position: "relative",
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#e3e3e3"
   },
-  leftWrap: {
-    overflow: 'hidden',
-    position: 'absolute',
-    top: 0,
-  },
-  rightWrap: {
-    position: 'absolute',
 
+  leftWrap: {
+    overflow: "hidden",
+    position: "absolute",
+    top: 0
   },
 
   loader: {
-    position: 'absolute',
+    position: "absolute",
     left: 0,
     top: 0,
-    borderRadius: 1000,
-
+    borderRadius: 1000
   },
 
   innerCircle: {
-    overflow: 'hidden',
-    position: 'relative',
-    justifyContent: 'center',
-    alignItems: 'center',
+    overflow: "hidden",
+    position: "relative",
+    justifyContent: "center",
+    alignItems: "center"
   },
+
   text: {
     fontSize: 11,
-    color: '#888',
-  },
+    color: "#888"
+  }
 });
+
+const deg = number => `${number}deg`;
+
+function Disabled(props) {
+  let { radius, disabledText } = props.data;
+  let diameter = radius * 2;
+  return (
+    <View
+      style={[
+        styles.circle,
+        {
+          width: diameter,
+          height: diameter,
+          borderRadius: radius
+        }
+      ]}
+    >
+      <Text style={styles.text}>{disabledText}</Text>
+    </View>
+  );
+}
+
+function RightTransformer(props) {
+  let { radius, rotate, color, percent } = props.data;
+  let diameter = radius * 2;
+  let half = percent >= 50;
+
+  let rightTransformerDegree = deg(half ? 180 : percent * 3.6);
+
+  return (
+    <View
+      style={[
+        styles.leftWrap,
+        {
+          width: radius,
+          height: diameter,
+          left: radius,
+          transform: [
+            { translateX: -radius / 2 },
+            { rotate: deg(rotate) },
+            { translateX: radius / 2 }
+          ]
+        }
+      ]}
+    >
+      <View
+        style={[
+          styles.loader,
+          {
+            left: -radius,
+            width: radius,
+            height: diameter,
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0,
+            backgroundColor: color,
+            transform: [
+              { translateX: radius / 2 },
+              { rotate: rightTransformerDegree },
+              { translateX: -radius / 2 }
+            ]
+          }
+        ]}
+      />
+    </View>
+  );
+}
+
+function LeftTransformer(props) {
+  let { radius, rotate, color, bgcolor, percent } = props.data;
+  let diameter = radius * 2;
+  let half = percent >= 50;
+
+  let leftTransformerDegree = deg(half ? (percent - 50) * 3.6 : 180);
+
+  return (
+    <View
+      style={[
+        styles.leftWrap,
+        {
+          width: radius,
+          height: diameter,
+          left: 0,
+          transform: [
+            { translateX: radius / 2 },
+            { rotate: deg(rotate) },
+            { translateX: -radius / 2 }
+          ]
+        }
+      ]}
+    >
+      <View
+        style={[
+          styles.loader,
+          {
+            left: radius,
+            width: radius,
+            height: diameter,
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+            backgroundColor: half ? color : bgcolor,
+            transform: [
+              { translateX: -radius / 2 },
+              { rotate: leftTransformerDegree },
+              { translateX: radius / 2 }
+            ]
+          }
+        ]}
+      />
+    </View>
+  );
+}
+
+function InnerCircle(props) {
+  let {
+    radius,
+    borderWidth,
+    innerColor,
+    percent,
+    textStyle,
+    children
+  } = props.data;
+
+  if (borderWidth < 2) borderWidth = 2;
+
+  return (
+    <View
+      style={[
+        styles.innerCircle,
+        {
+          width: (radius - borderWidth) * 2,
+          height: (radius - borderWidth) * 2,
+          borderRadius: radius - borderWidth,
+          backgroundColor: innerColor
+        }
+      ]}
+    >
+      {children ? (
+        children
+      ) : (
+        <Text style={[styles.text, ...textStyle]}>{percent}%</Text>
+      )}
+    </View>
+  );
+}
 
 class PercentageCircle extends Component {
   propTypes: {
-    color: React.PropTypes.string,
-    bgcolor: React.PropTypes.string,
-    innerColor: React.PropTypes.string,
-    radius: React.PropTypes.number,
-    percent: React.PropTypes.number,
-    borderWidth: React.Proptypes.number,
+    color: React.PropTypes.string, // 进度条颜色
+    bgcolor: React.PropTypes.string, // 背景条颜色
+    innerColor: React.PropTypes.string, // 环内区域背景色
+    radius: React.PropTypes.number, // 外圆半径
+    percent: React.PropTypes.number, // 进度（百分比分子）
+    borderWidth: React.Proptypes.number, // 环厚度（同心圆半径差值）
     textStyle: React.Proptypes.array,
     disabled: React.PropTypes.bool,
-  }
-
-  constructor(props) {
-    super(props);
-    let percent = this.props.percent;
-    let leftTransformerDegree = '0deg';
-    let rightTransformerDegree = '0deg';
-    if (percent >= 50) {
-      rightTransformerDegree = '180deg';
-      leftTransformerDegree = (percent - 50) * 3.6 + 'deg';
-    } else {
-      rightTransformerDegree = percent * 3.6 + 'deg';
-      leftTransformerDegree = '0deg';
-    }
-
-    this.state = {
-      percent: this.props.percent,
-      borderWidth: this.props.borderWidth < 2 || !this.props.borderWidth ? 2 : this.props.borderWidth,
-      leftTransformerDegree: leftTransformerDegree,
-      rightTransformerDegree: rightTransformerDegree,
-      textStyle: this.props.textStyle ? this.props.textStyle : null
-    };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    let percent = nextProps.percent;
-    let leftTransformerDegree = '0deg';
-    let rightTransformerDegree = '0deg';
-    if (percent >= 50) {
-      rightTransformerDegree = '180deg';
-      leftTransformerDegree = (percent - 50) * 3.6 + 'deg';
-    } else {
-      rightTransformerDegree = percent * 3.6 + 'deg';
-    }
-    this.setState({
-      percent: this.props.percent,
-      borderWidth: this.props.borderWidth < 2 || !this.props.borderWidth ? 2 : this.props.borderWidth,
-      leftTransformerDegree: leftTransformerDegree,
-      rightTransformerDegree: rightTransformerDegree
-    });
-  }
+    rotate: React.PropTypes.number // 进度环起点与 12 点方向的夹角 0 - 360 度
+  };
 
   render() {
-    if (this.props.disabled) {
-      return (
-        <View style={[styles.circle,{
-          width:this.props.radius*2,
-          height: this.props.radius*2,
-          borderRadius:this.props.radius
-        }]}>
-          <Text style={styles.text}>{this.props.disabledText}</Text>
-        </View>
-      );
-    }
-    return (
-      <View style={[styles.circle,{
-        width:this.props.radius*2,
-        height: this.props.radius*2,
-        borderRadius:this.props.radius,
-        backgroundColor: this.props.bgcolor
-      }]}>
-        <View style={[styles.leftWrap,{
-          width: this.props.radius,
-          height: this.props.radius * 2,
-          left:0,
-        }]}>
-          <View style={[styles.loader,{
-            left: this.props.radius,
-            width:this.props.radius,
-            height: this.props.radius*2,
-            borderTopLeftRadius:0,
-            borderBottomLeftRadius:0,
-            backgroundColor:this.props.color,
-            transform:[{translateX:-this.props.radius/2},{rotate:this.state.leftTransformerDegree},{translateX:this.props.radius/2}],
-          }]}></View>
-        </View>
-        <View style={[styles.leftWrap,{
-          left:this.props.radius,
-          width: this.props.radius,
-          height: this.props.radius * 2,
-        }]}>
-          <View style={[styles.loader,{
-            left:-this.props.radius,
-            width:this.props.radius,
-            height: this.props.radius*2,
-            borderTopRightRadius:0,
-            borderBottomRightRadius:0,
-            backgroundColor: this.props.color,
-            transform:[{translateX:this.props.radius/2},{rotate:this.state.rightTransformerDegree},{translateX:-this.props.radius/2}],
-          }]}></View>
-        </View>
-        <View style={[styles.innerCircle,{
-              width:(this.props.radius - this.state.borderWidth)*2,
-              height:(this.props.radius - this.state.borderWidth)*2,
-              borderRadius:this.props.radius - this.state.borderWidth,
-              backgroundColor: this.props.innerColor,
-            }]}>
-          {this.props.children ? this.props.children :
-            <Text style={[styles.text, this.state.textStyle]}>{this.props.percent}%</Text>}
-        </View>
+    let { bgcolor, disabled, radius } = this.props;
+    let diameter = radius * 2;
 
+    return disabled ? (
+      <Disabled data={this.props} />
+    ) : (
+      <View
+        style={[
+          styles.circle,
+          {
+            width: diameter,
+            height: diameter,
+            borderRadius: radius,
+            backgroundColor: bgcolor
+          }
+        ]}
+      >
+        {/* 右长方形，左半边圆 */}
+        <RightTransformer data={this.props} />
+
+        {/* 左长方形，右半圆 */}
+        <LeftTransformer data={this.props} />
+
+        {/* 圆环内部 */}
+        <InnerCircle data={this.props} />
       </View>
     );
   }
@@ -167,8 +264,12 @@ class PercentageCircle extends Component {
 
 // set some attributes default value
 PercentageCircle.defaultProps = {
-  bgcolor: '#e3e3e3',
-  innerColor: '#fff'
+  textStyle: [],
+  percent: 0,
+  borderWidth: 2,
+  bgcolor: "#e3e3e3",
+  innerColor: "#fff",
+  rotate: 0
 };
 
 module.exports = PercentageCircle;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-percentage-circle",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "react native percentage circle and also be a progress bar",
   "main": "index.js",
   "scripts": {
@@ -10,12 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/JackPu/react-native-percentage-circle.git"
   },
-  "keywords": [
-    "percentage",
-    "circle",
-    "progress",
-    "bar"
-  ],
+  "keywords": ["percentage", "circle", "progress", "bar"],
   "author": "jack pu",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
1. 修复 `percent` 小于 50 时，在安卓上进度条显示不正确的问题。
2. 修复  `textStyle` 在应用于 `Text` 时的类型错误。
3. 新增 `rotate` prop 用于自定义进度条的起始位置。