### PR TITLE
Reorder Circles

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     position: 'absolute',
     top: 0,
+    zIndex: 1,
   },
   rightWrap: {
     position: 'absolute',
@@ -42,6 +43,7 @@ const styles = StyleSheet.create({
     position: 'relative',
     justifyContent: 'center',
     alignItems: 'center',
+    zIndex: 2,
   },
   text: {
     fontSize: 11,


### PR DESCRIPTION
你好！

I've also stumbled upon the issue where percentages below 50 on Android are inverted when compared to iOS. I was able to reproduce it on RN 0.55. I read the related issues to the best of my knowledge in English and 汉语, but while testing locally this seemed to be the smallest change needed.

Fix: https://github.com/JackPu/react-native-percentage-circle/issues/19
Fix: https://github.com/JackPu/react-native-percentage-circle/issues/26
Fix: https://github.com/JackPu/react-native-percentage-circle/issues/27
Fix: https://github.com/JackPu/react-native-percentage-circle/issues/36

I hope it helps!